### PR TITLE
Add control for Up0 synchronization source.

### DIFF
--- a/drivers/isdn/hardware/mISDN/xhfc_su.c
+++ b/drivers/isdn/hardware/mISDN/xhfc_su.c
@@ -75,7 +75,14 @@ char *XHFC_PH_COMMANDS[] = {
 	"L1_SET_TESTLOOP_D",
 	"L1_UNSET_TESTLOOP_B1",
 	"L1_UNSET_TESTLOOP_B2",
-	"L1_UNSET_TESTLOOP_D"
+	"L1_UNSET_TESTLOOP_D",
+	"L1_SET_SYNC_SRC_INTF0",
+	"L1_SET_SYNC_SRC_INTF1",
+	"L1_SET_SYNC_SRC_INTF2",
+	"L1_SET_SYNC_SRC_INTF3",
+	"L1_SET_SYNC_SRC_SYNC_I",
+	"L1_SET_SYNC_SRC_MAN",
+	"L1_UNSET_SYNC_SRC_MAN"
 };
 
 
@@ -476,6 +483,41 @@ xhfc_ph_command(struct port *port, u_char command)
 			write_xhfc(xhfc, A_SL_CFG, 0);
 			write_xhfc(xhfc, R_SLOT, port->idx * 8 + 5);
 			write_xhfc(xhfc, A_SL_CFG, 0);
+			break;
+
+		case L1_SET_SYNC_SRC_INTF0:
+			/* source is line interface 0 */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_SYNC_SEL(xhfc->su_sync, 0x00));
+			break;
+
+		case L1_SET_SYNC_SRC_INTF1:
+			/* source is line interface 1 */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_SYNC_SEL(xhfc->su_sync, 0x01));
+			break;
+
+		case L1_SET_SYNC_SRC_INTF2:
+			/* source is line interface 2 */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_SYNC_SEL(xhfc->su_sync, 0x02));
+			break;
+
+		case L1_SET_SYNC_SRC_INTF3:
+			/* source is line interface 3 */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_SYNC_SEL(xhfc->su_sync, 0x03));
+			break;
+
+		case L1_SET_SYNC_SRC_SYNC_I:
+			/* source is SYNC_I signal */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_SYNC_SEL(xhfc->su_sync, 0x04));
+			break;
+
+		case L1_SET_SYNC_SRC_MAN:
+			/* manual sync source selection */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_MAN_SYNC(xhfc->su_sync, 0x01));
+			break;
+
+		case L1_UNSET_SYNC_SRC_MAN:
+			/* automatic sync source selection */
+			write_xhfc(xhfc, R_SU_SYNC, SET_V_MAN_SYNC(xhfc->su_sync, 0x00));
 			break;
 	}
 }
@@ -1213,6 +1255,40 @@ channel_ctrl(struct port *p, struct mISDN_ctrl_req *cq)
 				xhfc_ph_command(p, L1_SET_TESTLOOP_D);
 			} else {
 				xhfc_ph_command(p, L1_UNSET_TESTLOOP_D);
+			}
+			spin_unlock_bh(&p->xhfc->lock);
+			break;
+
+		case MISDN_CTRL_SYNC:
+			/*
+			 * control sync source
+			 *
+			 */
+			if ((cq->channel < 0) || (cq->channel > 7)) {
+				ret = -EINVAL;
+				break;
+			}
+
+			spin_lock_bh(&p->xhfc->lock);
+			if (cq->sync & 1) {
+				xhfc_ph_command(p, L1_SET_SYNC_SRC_INTF0);
+			}
+			if (cq->sync & 2) {
+				xhfc_ph_command(p, L1_SET_SYNC_SRC_INTF1);
+			}
+			if (cq->sync & 3) {
+				xhfc_ph_command(p, L1_SET_SYNC_SRC_INTF2);
+			}
+			if (cq->sync & 4) {
+				xhfc_ph_command(p, L1_SET_SYNC_SRC_INTF3);
+			}
+			if (cq->sync & 5) {
+				xhfc_ph_command(p, L1_SET_SYNC_SRC_SYNC_I);
+			}
+			if (cq->sync & 6) {
+				xhfc_ph_command(p, L1_SET_SYNC_SRC_MAN);
+			} else {
+				xhfc_ph_command(p, L1_UNSET_SYNC_SRC_MAN);
 			}
 			spin_unlock_bh(&p->xhfc->lock);
 			break;

--- a/drivers/isdn/hardware/mISDN/xhfc_su.h
+++ b/drivers/isdn/hardware/mISDN/xhfc_su.h
@@ -94,6 +94,19 @@
 #define L1_UNSET_TESTLOOP_B2		0x08
 #define L1_UNSET_TESTLOOP_D		0x09
 
+/* source is line interface N (R_SU_SYNC register bits 2..0) */
+#define L1_SET_SYNC_SRC_INTF0	0x0A
+#define L1_SET_SYNC_SRC_INTF1	0x0B
+#define L1_SET_SYNC_SRC_INTF2	0x0C
+#define L1_SET_SYNC_SRC_INTF3	0x0D
+
+/* source is SYNC_I signal */
+#define L1_SET_SYNC_SRC_SYNC_I	0x0E
+
+/* automatic synchronization source selection (R_SU_SYNC register bit 3) */
+#define L1_SET_SYNC_SRC_MAN	0x0F
+#define L1_UNSET_SYNC_SRC_MAN	0x10
+
 
 /* xhfc Layer1 Flags (stored in xhfc_port_t->l1_flags) */
 #define HFC_L1_ACTIVATING	1
@@ -187,6 +200,8 @@ struct xhfc {
 	__u8 ti_wd;		/* timer interval */
 	__u8 pcm_md0;
 	__u8 pcm_md1;
+
+	__u8 su_sync;		/* ST/Up synchronization */
 
 	__u32 fifo_irq;		/* fifo bl irq */
 	__u32 fifo_irqmsk;	/* fifo bl irq */

--- a/drivers/isdn/mISDN/socket.c
+++ b/drivers/isdn/mISDN/socket.c
@@ -257,6 +257,8 @@ data_sock_release(struct socket *sock)
 	switch (sk->sk_protocol) {
 	case ISDN_P_TE_S0:
 	case ISDN_P_NT_S0:
+	case ISDN_P_TE_UP0:
+	case ISDN_P_NT_UP0:
 	case ISDN_P_TE_E1:
 	case ISDN_P_NT_E1:
 		if (sk->sk_state == MISDN_BOUND)
@@ -526,6 +528,8 @@ data_sock_bind(struct socket *sock, struct sockaddr *addr, int addr_len)
 	switch (sk->sk_protocol) {
 	case ISDN_P_TE_S0:
 	case ISDN_P_NT_S0:
+	case ISDN_P_TE_UP0:
+	case ISDN_P_NT_UP0:
 	case ISDN_P_TE_E1:
 	case ISDN_P_NT_E1:
 		mISDN_sock_unlink(&data_sockets, sk);
@@ -795,6 +799,8 @@ mISDN_sock_create(struct net *net, struct socket *sock, int proto, int kern)
 		break;
 	case ISDN_P_TE_S0:
 	case ISDN_P_NT_S0:
+	case ISDN_P_TE_UP0:
+	case ISDN_P_NT_UP0:
 	case ISDN_P_TE_E1:
 	case ISDN_P_NT_E1:
 	case ISDN_P_LAPD_TE:

--- a/drivers/isdn/mISDN/stack.c
+++ b/drivers/isdn/mISDN/stack.c
@@ -439,8 +439,10 @@ connect_layer1(struct mISDNdevice *dev, struct mISDNchannel *ch,
 		       adr->channel, adr->sapi, adr->tei);
 	switch (protocol) {
 	case ISDN_P_NT_S0:
+	case ISDN_P_NT_UP0:
 	case ISDN_P_NT_E1:
 	case ISDN_P_TE_S0:
+	case ISDN_P_TE_UP0:
 	case ISDN_P_TE_E1:
 		ch->recv = mISDN_queue_message;
 		ch->peer = &dev->D.st->own;
@@ -590,7 +592,9 @@ delete_channel(struct mISDNchannel *ch)
 	}
 	switch (ch->protocol) {
 	case ISDN_P_NT_S0:
+	case ISDN_P_NT_UP0:
 	case ISDN_P_TE_S0:
+	case ISDN_P_TE_UP0:
 	case ISDN_P_NT_E1:
 	case ISDN_P_TE_E1:
 		write_lock_bh(&ch->st->l1sock.lock);

--- a/include/linux/mISDNif.h
+++ b/include/linux/mISDNif.h
@@ -387,6 +387,7 @@ clear_channelmap(u_int nr, u_char *map)
 #define MISDN_CTRL_HFC_ECHOCAN_OFF 	0x4008
 #define MISDN_CTRL_HFC_WD_INIT		0x4009
 #define MISDN_CTRL_HFC_WD_RESET		0x400A
+#define MISDN_CTRL_SYNC			0xFFFF
 
 /* special RX buffer value for MISDN_CTRL_RX_BUFFER request.p1 is the minimum
  * buffer size request.p2 the maximum. Using  MISDN_CTRL_RX_SIZE_IGNORE will
@@ -400,6 +401,7 @@ clear_channelmap(u_int nr, u_char *map)
 struct mISDN_ctrl_req {
 	int		op;
 	int		channel;
+	int		sync;
 	int		p1;
 	int		p2;
 };


### PR DESCRIPTION
This patch adds the ability to select the Up0 synchronization source between:

- hardware interfaces,
- the extern SYNC_I signal,
- as well as the automatic sync source selection

and can be of help for Up0 loopback tests.